### PR TITLE
Update text regex to fix :b: and others

### DIFF
--- a/Common/src/main/java/com/hrznstudio/emojiful/api/Emoji.java
+++ b/Common/src/main/java/com/hrznstudio/emojiful/api/Emoji.java
@@ -122,18 +122,12 @@ public class Emoji implements Predicate<String> {
         if (textRegex != null) return textRegex;
         List<String> processed = new ArrayList<>();
         for (String string : texts) {
-            char last = string.toLowerCase().charAt(string.length() - 1);
-            String s = string;
-            if (last >= 97 && last <= 122) {
-                s = string + "\\b";
-            }
-            char first = string.toLowerCase().charAt(0);
-            if (first >= 97 && first <= 122) {
-                s = "\\b" + s;
-            }
-            processed.add(EmojiUtil.cleanStringForRegex(s));
+            processed.add(EmojiUtil.cleanStringForRegex(string));
         }
-        textRegex = String.join("|", processed);
+
+        // (?<=^|\s) ensures the character before the text is either the start of the string or a whitespace
+        // (?=$|\s) ensures the character after the text is either the end of the string or a whitespace
+        textRegex = "(?<=^|\\s)(" + String.join("|", processed) + ")(?=$|\\s)";
         return textRegex;
     }
 


### PR DESCRIPTION
Fixes #40 by only replacing short emoticons (`:b`, `:)`, `>:-(`, etc.) if there are no non-whitespace characters surrounding them. This matches the behavior of Discord and solves any potential conflicts with short and long emoji forms like `:b:`.