### PR TITLE
Fix emoji rendering when ":" symbol is present

### DIFF
--- a/Common/src/main/java/com/hrznstudio/emojiful/render/EmojiFontRenderer.java
+++ b/Common/src/main/java/com/hrznstudio/emojiful/render/EmojiFontRenderer.java
@@ -177,7 +177,7 @@ public class EmojiFontRenderer extends Font {
                             return true;
                         }
                     }
-                    if (ch == ':') {
+                    if (ignore.get() && ch == ':') {
                         ignore.set(false);
                         cleanPos.getAndIncrement();
                     }


### PR DESCRIPTION
Fixes a long-standing issue (#26) where chat formatting that includes a colon breaks emoji rendering on clients.

![proof of working](https://user-images.githubusercontent.com/6946558/197383484-21ebec33-7d49-4f79-b799-c2afc0560dd9.png)
![image](https://user-images.githubusercontent.com/6946558/197384170-1c591cda-dfdd-4ad5-8f91-645209b4a4cd.png)

