### PR TITLE
Chat bed fix

### DIFF
--- a/Common/src/main/java/com/hrznstudio/emojiful/gui/EmojifulBedChatScreen.java
+++ b/Common/src/main/java/com/hrznstudio/emojiful/gui/EmojifulBedChatScreen.java
@@ -1,18 +1,15 @@
 package com.hrznstudio.emojiful.gui;
 
+
 import com.hrznstudio.emojiful.Constants;
 import com.hrznstudio.emojiful.platform.Services;
 import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.gui.screens.ChatScreen;
+import net.minecraft.client.gui.screens.InBedChatScreen;
 
-public class EmojifulChatScreen extends ChatScreen {
+public class EmojifulBedChatScreen extends InBedChatScreen {
 
     private EmojiSelectionGui emojiSelectionGui;
     private EmojiSuggestionHelper emojiSuggestionHelper;
-
-    public EmojifulChatScreen(String initial) {
-        super(initial);
-    }
 
     @Override
     protected void init() {
@@ -37,7 +34,7 @@ public class EmojifulChatScreen extends ChatScreen {
 
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        if (super.keyPressed(keyCode, scanCode, modifiers) && keyCode != 258){
+        if (super.keyPressed(keyCode, scanCode, modifiers)){
             return true;
         }
         if (emojiSuggestionHelper != null && emojiSuggestionHelper.keyPressed(keyCode, scanCode, modifiers))
@@ -60,4 +57,5 @@ public class EmojifulChatScreen extends ChatScreen {
     public boolean charTyped(char c, int i) {
         return super.charTyped(c, i) && (emojiSelectionGui != null && emojiSelectionGui.charTyped(c, i));
     }
+
 }

--- a/Common/src/main/java/com/hrznstudio/emojiful/gui/EmojifulBedChatScreen.java
+++ b/Common/src/main/java/com/hrznstudio/emojiful/gui/EmojifulBedChatScreen.java
@@ -5,6 +5,7 @@ import com.hrznstudio.emojiful.Constants;
 import com.hrznstudio.emojiful.platform.Services;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.gui.screens.InBedChatScreen;
+import org.lwjgl.glfw.GLFW;
 
 public class EmojifulBedChatScreen extends InBedChatScreen {
 
@@ -34,7 +35,7 @@ public class EmojifulBedChatScreen extends InBedChatScreen {
 
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        if (super.keyPressed(keyCode, scanCode, modifiers)){
+        if (super.keyPressed(keyCode, scanCode, modifiers) && keyCode != GLFW.GLFW_KEY_TAB){
             return true;
         }
         if (emojiSuggestionHelper != null && emojiSuggestionHelper.keyPressed(keyCode, scanCode, modifiers))

--- a/Common/src/main/java/com/hrznstudio/emojiful/gui/EmojifulChatScreen.java
+++ b/Common/src/main/java/com/hrznstudio/emojiful/gui/EmojifulChatScreen.java
@@ -4,6 +4,7 @@ import com.hrznstudio.emojiful.Constants;
 import com.hrznstudio.emojiful.platform.Services;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.gui.screens.ChatScreen;
+import org.lwjgl.glfw.GLFW;
 
 public class EmojifulChatScreen extends ChatScreen {
 
@@ -37,7 +38,7 @@ public class EmojifulChatScreen extends ChatScreen {
 
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        if (super.keyPressed(keyCode, scanCode, modifiers) && keyCode != 258){
+        if (super.keyPressed(keyCode, scanCode, modifiers) && keyCode != GLFW.GLFW_KEY_TAB){
             return true;
         }
         if (emojiSuggestionHelper != null && emojiSuggestionHelper.keyPressed(keyCode, scanCode, modifiers))

--- a/Common/src/main/resources/emojifulcommon.accesswidener
+++ b/Common/src/main/resources/emojifulcommon.accesswidener
@@ -17,3 +17,4 @@ accessible field net/minecraft/client/gui/Font filterFishyGlyphs Z
 accessible method net/minecraft/client/gui/Font getFontSet (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/gui/font/FontSet;
 accessible method net/minecraft/client/gui/Font renderChar (Lnet/minecraft/client/gui/font/glyphs/BakedGlyph;ZZFFFLcom/mojang/math/Matrix4f;Lcom/mojang/blaze3d/vertex/VertexConsumer;FFFFI)V
 accessible field net/minecraft/client/gui/Font fonts Ljava/util/function/Function;
+accessible field net/minecraft/client/gui/screens/ChatScreen initial Ljava/lang/String;

--- a/Fabric/src/main/java/com/hrznstudio/emojiful/EmojifulFabric.java
+++ b/Fabric/src/main/java/com/hrznstudio/emojiful/EmojifulFabric.java
@@ -2,12 +2,14 @@ package com.hrznstudio.emojiful;
 
 import com.hrznstudio.emojiful.datapack.EmojiRecipe;
 import com.hrznstudio.emojiful.datapack.EmojiRecipeSerializer;
+import com.hrznstudio.emojiful.gui.EmojifulBedChatScreen;
 import com.hrznstudio.emojiful.gui.EmojifulChatScreen;
 import com.hrznstudio.emojiful.platform.FabricConfigHelper;
 import eu.midnightdust.lib.config.MidnightConfig;
 import net.fabricmc.api.ModInitializer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.ChatScreen;
+import net.minecraft.client.gui.screens.InBedChatScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -28,10 +30,19 @@ public class EmojifulFabric implements ModInitializer {
         //This compiles to another class, so we get a classloading barrier
         public static void handleScreenInject(Minecraft minecraft, Screen screen) {
             if (screen != null) {
-                if (screen instanceof ChatScreen && !(screen instanceof EmojifulChatScreen)) {
-                    minecraft.screen = new EmojifulChatScreen();
-                    minecraft.screen.init(minecraft, minecraft.getWindow().getGuiScaledWidth(), minecraft.getWindow().getGuiScaledHeight());
-                } else {
+                if (!(screen instanceof EmojifulChatScreen)){
+                    if (screen instanceof InBedChatScreen){
+                        minecraft.screen = new EmojifulBedChatScreen();
+                        minecraft.screen.init(minecraft, minecraft.getWindow().getGuiScaledWidth(), minecraft.getWindow().getGuiScaledHeight());
+                    }
+
+                    else if (screen instanceof ChatScreen chatScreen) {
+                        minecraft.screen = new EmojifulChatScreen(chatScreen.initial);
+                        minecraft.screen.init(minecraft, minecraft.getWindow().getGuiScaledWidth(), minecraft.getWindow().getGuiScaledHeight());
+                    }
+
+                }
+                else {
                     minecraft.screen = screen;
                 }
             } else {

--- a/Fabric/src/main/java/com/hrznstudio/emojiful/EmojifulFabric.java
+++ b/Fabric/src/main/java/com/hrznstudio/emojiful/EmojifulFabric.java
@@ -30,17 +30,15 @@ public class EmojifulFabric implements ModInitializer {
         //This compiles to another class, so we get a classloading barrier
         public static void handleScreenInject(Minecraft minecraft, Screen screen) {
             if (screen != null) {
-                if (!(screen instanceof EmojifulChatScreen)){
+                if (!(screen instanceof EmojifulChatScreen) && screen instanceof ChatScreen){
                     if (screen instanceof InBedChatScreen){
                         minecraft.screen = new EmojifulBedChatScreen();
                         minecraft.screen.init(minecraft, minecraft.getWindow().getGuiScaledWidth(), minecraft.getWindow().getGuiScaledHeight());
                     }
-
-                    else if (screen instanceof ChatScreen chatScreen) {
-                        minecraft.screen = new EmojifulChatScreen(chatScreen.initial);
+                    else  {
+                        minecraft.screen = new EmojifulChatScreen(((ChatScreen) screen).initial);
                         minecraft.screen.init(minecraft, minecraft.getWindow().getGuiScaledWidth(), minecraft.getWindow().getGuiScaledHeight());
                     }
-
                 }
                 else {
                     minecraft.screen = screen;

--- a/Forge/src/main/java/com/hrznstudio/emojiful/ForgeClientHandler.java
+++ b/Forge/src/main/java/com/hrznstudio/emojiful/ForgeClientHandler.java
@@ -1,8 +1,11 @@
 package com.hrznstudio.emojiful;
 
+import com.hrznstudio.emojiful.gui.EmojifulBedChatScreen;
 import com.hrznstudio.emojiful.gui.EmojifulChatScreen;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.ChatScreen;
+import net.minecraft.client.gui.screens.InBedChatScreen;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraftforge.client.event.RecipesUpdatedEvent;
 import net.minecraftforge.client.event.ScreenEvent;
 
@@ -14,9 +17,17 @@ public class ForgeClientHandler {
     }
 
     public static void hijackScreen(final ScreenEvent.Opening event) {
-        if (event.getNewScreen() instanceof ChatScreen && !(event.getNewScreen() instanceof EmojifulChatScreen)) {
+        final Screen newScreen = event.getNewScreen();
+        if (newScreen instanceof EmojifulChatScreen || newScreen instanceof EmojifulBedChatScreen){
+            return;
+        }
+        if (event.getNewScreen() instanceof InBedChatScreen){
             event.setCanceled(true);
-            Minecraft.getInstance().setScreen(new EmojifulChatScreen());
+            Minecraft.getInstance().setScreen(new EmojifulBedChatScreen());
+        }
+        else if (event.getNewScreen() instanceof ChatScreen chatScreen) {
+            event.setCanceled(true);
+            Minecraft.getInstance().setScreen(new EmojifulChatScreen(chatScreen.initial));
         }
     }
 }

--- a/Forge/src/main/resources/META-INF/accesstransformer.cfg
+++ b/Forge/src/main/resources/META-INF/accesstransformer.cfg
@@ -10,3 +10,4 @@ public net.minecraft.client.gui.Font f_242994_ # filterFishyGlyphs
 public net.minecraft.client.gui.Font m_92787_(Lnet/minecraft/client/gui/font/glyphs/BakedGlyph;ZZFFFLcom/mojang/math/Matrix4f;Lcom/mojang/blaze3d/vertex/VertexConsumer;FFFFI)V # renderChar
 public net.minecraft.client.gui.Font m_92863_(Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/gui/font/FontSet; # getFontSet
 public net.minecraft.client.gui.Font f_92713_ # fonts
+public net.minecraft.client.gui.screens.ChatScreen f_95576_ # initial

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,8 @@ common_server_run_name=Common Server
 forge_version=43.1.32
 
 # Fabric
-fabric_version=0.62.0+1.19.2
-fabric_loader_version=0.14.9
+fabric_version=0.64.0+1.19.2
+fabric_loader_version=0.14.10
 
 # Quilt
 quilt_loader_version=0.17.3


### PR DESCRIPTION
Fix #53 and #54 
Introduces a custom ChatBedScreen that works as the vanilla counterpart
Makes sure that pressing esc on a chat screen properly pops the Screen instead of opening the pause menu.
